### PR TITLE
fixed a bug where client_id and client_secret option for provisioning…

### DIFF
--- a/drone-ci/drone/ansible/dronerc_tmpl.j2
+++ b/drone-ci/drone/ansible/dronerc_tmpl.j2
@@ -1,4 +1,8 @@
 REMOTE_DRIVER=github
-REMOTE_CONFIG={{ github_remote_config_url }}
+{% if lookup('env', 'DRONE_GITHUB_CONFIG_URL') %}
+REMOTE_CONFIG={{ lookup('env', 'DRONE_GITHUB_CONFIG_URL') }}
+{% else %}
+REMOTE_CONFIG={{ github_default_config_url }}
+{% endif %}
 DATABASE_DRIVER=sqlite3
 DATABASE_CONFIG=/var/lib/drone/drone.sqlite

--- a/drone-ci/drone/ansible/vars.yml
+++ b/drone-ci/drone/ansible/vars.yml
@@ -19,4 +19,4 @@ drone_local_dir_path: "{{ system_data_dir }}/drone"
 drone_github_client_id: "{{ lookup('env', 'DRONE_GITHUB_CLIENT_ID') }}"
 drone_github_client_secret: "{{ lookup('env', 'DRONE_GITHUB_CLIENT_SECRET') }}"
 github_default_config_url: "https://github.com?client_id={{ drone_github_client_id }}&client_secret={{ drone_github_client_secret }}"
-github_remote_config_url: "{{ lookup('env', 'DRONE_GITHUB_CONFIG_URL') | default(github_default_config_url) }}"
+


### PR DESCRIPTION
… was always ignored in some systems.

Form some reasons, some times, undefined env variables were taken as null by Jinja and some other times as empty string.

This lead into a problem where the URL defined in DRONE_GITHUB_CONFIG_URL was always used even if the variable was not defined preventing the user from using the client_id and secret_id through DRONE_GITHUB_CLIENT_ID and DRONE_GITHUB_CLIENT_SECRET env vars.