### PR TITLE
Drone 0.5 improvements

### DIFF
--- a/drone-ci/README.md
+++ b/drone-ci/README.md
@@ -10,11 +10,20 @@ The setup requires Terraform (it has been tested with version 0.7.x) and Ansible
 
 ```
 module "drone" {
-  source = "github.com/nearform/labs-devops//drone-ci/drone"
-  keypair_key = "<your-public-key>"
-  private_key_path = "~/.ssh/id_rsa"
-  drone_vpc_id = "12345"
-  drone_subnet_id = "678910"
+  source = "github.com/nearform/labs-devops/drone-ci/drone"
+  ssh_key_name = "infra-key"
+  ssh_private_key = "~/.ssh/infra-key.pem"
+  aws_subnet = "subnet_id_1"
+  aws_zone = "eu-west-1a"
+  aws_security_groups = ["sec_group_id_1", "sec_group_id_2"]
+  instance_type = "t2.small"
+  aws_base_ami = "ami-82cf0aed" ## expects an Ubuntu 16.04 AMI id
+  instance_tag = "my-drone-ec2"
+  volume_type = "gp2"
+  volume_size = 10
+  volume_tag = "my-drone-volume"
+  ansible_inventory_path = "/tmp/drone-inventory"
+  use_private_ip_to_provision = false
 }
 
 output "drone-ip" {
@@ -66,10 +75,5 @@ There is one field called `Authorization callback URL`. This field needs to poin
 Next you need to add `.drone.yml` files to your code repositories, see the [Drone Documentation](http://readme.drone.io/usage/overview/) for more on this.
 
 ## Security Considerations
-
-By default, this module creates a security group allowing traffic from every source into the port 80 (for HTTP) and into
-the port 22 (for SSH).
-
-The security group associated to it is called `Drone security group` in the AWS console so customize it as you need.
 
 We do not recommend creating a public facing Drone server directly on the internet - instead adopt one of the recommended AWS VPC [patterns](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Scenario2.html).

--- a/drone-ci/README.md
+++ b/drone-ci/README.md
@@ -4,6 +4,14 @@ This is a Terraform module to provision infrastructure for a [Drone](https://dro
 
 The setup requires Terraform (it has been tested with version 0.7.x) and Ansible (any version but tested with 2.1.X).
 
+#### Dependencies
+
+As you can see in the example some AWS resources needs to be already defined and passed as variables to the module. This will guarantee a nice level of customization and integration with existing infrastructure.
+
+The security group **must** allow connections on port `8000` and `22` for allowing ansible to provision the EC2 instance. Once provisioned you can safely remove the `ingress` rule on port 22 from your security group.
+
+**NOTE:** The module will spawn a drone insance listing on port `8000`
+
 ## Setup
 
 1) Create a `main.tf` terraform file:

--- a/drone-ci/README.md
+++ b/drone-ci/README.md
@@ -18,7 +18,7 @@ The security group **must** allow connections on port `8000` and `22` for allowi
 
 ```
 module "drone" {
-  source = "github.com/nearform/labs-devops/drone-ci/drone"
+  source = "github.com/nearform/labs-devops//drone-ci/drone"
   ssh_key_name = "infra-key"
   ssh_private_key = "~/.ssh/infra-key.pem"
   aws_subnet = "subnet_id_1"

--- a/drone-ci/drone/ansible/play.yml
+++ b/drone-ci/drone/ansible/play.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: drone
+- hosts: all
   remote_user: ubuntu
   gather_facts: False
   vars_files:
@@ -14,10 +14,25 @@
         wait_for host="{{ inventory_hostname }}"
         port=22
         state=started
-    - name: update apt cache
-      raw: "sudo apt-get update"
-    - name: install python 2.7 and aptitude
-      raw: "sudo apt-get install -qq python2.7 aptitude"
+    - name: update package list
+      raw: sudo apt-get -y update
+      register: result
+      until: result|success
+      retries: 10
+    - name: install python2
+      raw: sudo apt-get update && sudo apt-get -y install python2.7
+      register: result
+      until: result|success
+      retries: 10
+    - name: install aptitude
+      raw: sudo apt-get update && sudo apt-get -y install aptitude
+      register: result
+      until: result|success
+      retries: 10
+    - name: upgrade to latest
+      become: yes
+      apt:
+        upgrade: safe
     - name: get instance hostname
       shell:
         cmd: cat /etc/hostname
@@ -113,7 +128,6 @@
       docker_container:
         name: drone-server
         network_mode: host
-        #command: server
         image: drone/drone:0.5
         pull: yes
         restart_policy: always
@@ -123,7 +137,7 @@
           - /var/run/docker.sock:/var/run/docker.sock
         env_file: "{{ drone_local_dir_path }}/dronerc"
         published_ports:
-          - 80:8000
+          - 8000:8000
     - name: run drone agent
       docker_container:
         name: drone-agent

--- a/drone-ci/drone/ansible/vars.yml
+++ b/drone-ci/drone/ansible/vars.yml
@@ -8,7 +8,6 @@ docker_apt_repo_url: "https://apt.dockerproject.org/repo ubuntu-xenial main"
 apt_packages:
   - apt-transport-https
   - ca-certificates
-  - htop
   - docker-engine
   - python-dev
   - python-pip

--- a/drone-ci/drone/outputs.tf
+++ b/drone-ci/drone/outputs.tf
@@ -10,10 +10,6 @@ output "reprovision-command" {
   value = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ${var.ansible_inventory_path} --private-key ${var.private_key_path} ${path.module}/ansible/play.yml"
 }
 
-output "sg-id" {
-  value = "${aws_security_group.drone.id}"
-}
-
 output "instance-id" {
   value = "${aws_instance.drone.id}"
 }

--- a/drone-ci/drone/resources.tf
+++ b/drone-ci/drone/resources.tf
@@ -1,77 +1,28 @@
-
-
-provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-  region = "${var.aws_region}"
-}
-
-resource "aws_key_pair" "user" {
-  key_name = "${var.keypair_name}"
-  public_key = "${var.keypair_key}"
-}
-
-resource "aws_security_group" "drone" {
-  name = "${var.aws_security_group_name}"
-  description = "${var.aws_security_group_name}"
-  vpc_id = "${var.drone_vpc_id}"
-  ingress {
-    from_port = 22
-    to_port = 22
-    protocol = "tcp"
-    cidr_blocks = [
-     "0.0.0.0/0"
-    ]
-  }
-  ingress {
-    from_port = 8000
-    to_port = 8000
-    protocol = "tcp"
-    cidr_blocks = [
-     "0.0.0.0/0"
-    ]
-  }
-  egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    cidr_blocks = [
-      "0.0.0.0/0"
-    ]
-  }
-
+resource "aws_ebs_volume" "volume" {
+  availability_zone = "${var.aws_zone}"
+  type = "${var.volume_type}"
+  size = "${var.volume_size}"
   tags {
-    Name = "${var.aws_security_group_name}"
-  }
-}
-
-resource "aws_ebs_volume" "drone-volume" {
-  availability_zone = "${data.aws_availability_zones.available-zones.names[0]}"
-  type = "${var.aws_volume_type}"
-  size = "${var.drone_volume_size}"
-  tags {
-    Name = "${var.aws_volume_tag}"
+    Name = "${var.volume_tag}"
   }
 }
 
 resource "aws_instance" "drone" {
-  key_name = "${var.keypair_name}"
+  key_name = "${var.ssh_key_name}"
   ami = "${var.aws_base_ami}"
-  instance_type = "${var.aws_instance_type}"
-  availability_zone = "${data.aws_availability_zones.available-zones.names[0]}"
-  subnet_id = "${var.drone_subnet_id}"
-  vpc_security_group_ids = [
-    "${aws_security_group.drone.id}"
-  ]
-  private_ip = "${var.drone_private_ip}"
+  instance_type = "${var.instance_type}"
+  availability_zone = "${var.aws_zone}"
+  subnet_id = "${var.aws_subnet}"
+  vpc_security_group_ids = ["${var.aws_security_groups}"]
+  private_ip = "${var.private_ip}"
   tags {
-      Name = "${var.aws_instance_tag}"
+      Name = "${var.instance_tag}"
   }
 }
 
 resource "aws_volume_attachment" "default" {
   device_name = "/dev/sdh"
-  volume_id = "${aws_ebs_volume.drone-volume.id}"
+  volume_id = "${aws_ebs_volume.volume.id}"
   instance_id = "${aws_instance.drone.id}"
   force_detach = true
 
@@ -79,9 +30,9 @@ resource "aws_volume_attachment" "default" {
     command = <<EOF
       if [ 1 -eq ${var.use_private_ip_to_provision} ]
       then
-        echo "[drone]\n${aws_instance.drone.private_ip}" > ${var.ansible_inventory_path};
+        echo "${aws_instance.drone.private_ip}" > ${var.ansible_inventory_path};
       else
-        echo "[drone]\n${aws_instance.drone.public_ip}" > ${var.ansible_inventory_path};
+        echo "${aws_instance.drone.public_ip}" > ${var.ansible_inventory_path};
       fi
       ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i ${var.ansible_inventory_path} --private-key ${var.private_key_path} ${path.module}/ansible/play.yml
     EOF

--- a/drone-ci/drone/variables.tf
+++ b/drone-ci/drone/variables.tf
@@ -1,41 +1,14 @@
-data "aws_availability_zones" "available-zones" {}
-
-variable "aws_region" {
-  type = "string"
-  default = "eu-central-1"
-}
-
-variable "aws_access_key" {
+## aws
+variable "aws_subnet" {
   type = "string"
   default = ""
 }
 
-variable "aws_secret_key" {
+variable "aws_zone" {
   type = "string"
   default = ""
 }
 
-variable "aws_instance_type" {
-  type = "string"
-  default = "t2.micro"
-}
-
-variable "aws_volume_type" {
-  type = "string"
-  default = "gp2"
-}
-
-variable "aws_instance_tag" {
-  type = "string"
-  default = "Drone CI"
-}
-
-variable "aws_volume_tag" {
-  type = "string"
-  default = "Drone CI"
-}
-
-// TODO - it's possible to query this automatically
 variable "aws_base_ami" {
   # Ubuntu 16.04 amd64 server - 2016-08-30
   # Root device type: ebs
@@ -43,52 +16,55 @@ variable "aws_base_ami" {
   default = "ami-82cf0aed"
 }
 
-variable "aws_security_group_name" {
-  default = "Drone security group"
-}
-
-variable "drone_volume_size" {
-  default = "8"
-}
-
-variable "keypair_name" {
-  type = "string"
-  default = "drone-ssh-key"
-}
-
-variable "keypair_key" {
-  type = "string"
-}
-
-variable "drone_subnet_id" {
-  type = "string"
-}
-
-variable "drone_vpc_id" {
-  type = "string"
-}
-
-variable "drone_security_groups" {
+variable "aws_security_groups" {
   default = []
 }
 
-variable "drone_private_ip" {
+variable "private_ip" {
+  default = ""
+}
+
+## volume
+variable "volume_type" {
+  type = "string"
+  default = "gp2"
+}
+
+variable "volume_size" {
+  default = "8"
+}
+
+variable "volume_tag" {
+  type = "string"
+  default = "Drone CI"
+}
+
+## instance
+variable "instance_type" {
+  type = "string"
+  default = "t2.micro"
+}
+
+variable "instance_tag" {
+  type = "string"
+  default = "Drone CI"
+}
+
+# ssh
+variable "ssh_key_name" {
+  type = "string"
+  default = "sps-ci-bot"
+}
+
+variable "ssh_private_key" {
   type = "string"
   default = ""
 }
 
-variable "ansible_user" {
-  type = "string"
-  default = "ubuntu"
-}
-
+# ansible
 variable "ansible_inventory_path" {
   type = "string"
   default = "/tmp/inventory"
-}
-
-variable "private_key_path" {
-  type = "string"
 }
 
 variable "use_private_ip_to_provision" {

--- a/drone-ci/example.tf
+++ b/drone-ci/example.tf
@@ -1,6 +1,6 @@
 # This file is only an example. Please see the README.md for more info
 module "drone" {
-  source = "github.com/nearform/labs-devops/drone-ci/drone"
+  source = "github.com/nearform/labs-devops//drone-ci/drone"
   # we reuse a key already create in AWS passing just it's name and the
   # path of the private key used to connect to the machine for provisioning
   ssh_key_name = ""

--- a/drone-ci/example.tf
+++ b/drone-ci/example.tf
@@ -1,10 +1,25 @@
 # This file is only an example. Please see the README.md for more info
-
 module "drone" {
-  source = "github.com/nearform/labs-devops//drone-ci/drone"
-  public_ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/eADYZQ1gUrxP4sfHi/H07dm9M0KnjYnmcY1Ek8rrPzR1gCEsC+JThZC446AdKHbsNHOIlo+XL5yNYwHKRwKgtnE0uGQi/yJNQvxQpE1fqp/cCRQxoJZ34DJkO0HJAtq4miU/dMLTsmLSDR6VOB10SDF7kwMxpSveOrBBMe0dj/MgtlnQSJJBSpb/rfwCq0EWTmajcgx21F8/msBak/isPPYSi6IlKMwgSTbV4xjDsTcjww0BpyiWoUCw2CE9fDeZw5PdHqWXo895ENVtcHf9FdM8JoZks8mHLEnu5B813Ez+nWS9eJjwWmZq5LmIyVHJCrEohUcS8hX/qWErEfDX dgonzalez@Davids-iMac.local"
-  private_key_path = "~/.ssh/kube_aws_rsa"
-  provision_through_private_ip = false
+  source = "github.com/nearform/labs-devops/drone-ci/drone"
+  # we reuse a key already create in AWS passing just it's name and the
+  # path of the private key used to connect to the machine for provisioning
+  ssh_key_name = ""
+  ssh_private_key = "~/.ssh/my_pem_file"
+  # configure networking and security
+  aws_subnet = "subnet_id_1"
+  aws_zone = "eu-west-1a"
+  aws_security_groups = ["sec_group_id_1", "sec_group_id_2"]
+  # instance settings
+  instance_type = "t2.small"
+  aws_base_ami = "ami-82cf0aed" ## expects an Ubuntu 16.04 AMI id
+  instance_tag = "my-drone-ec2"
+  # external volume settings
+  volume_type = "gp2"
+  volume_size = 10
+  volume_tag = "my-drone-volume"
+  # asnible settings
+  ansible_inventory_path = "/tmp/drone-inventory"
+  use_private_ip_to_provision = false
 }
 
 output "drone-ip" {


### PR DESCRIPTION
This PR adds some improvements to the current `drone-0.5` branch.

#### Changes applied:

- removed provider
- removed security group
- removed SSH key creation
- changed `ansible` setup base for `Ubuntu 16.04` in order to use retry strategies (AWS network is not very reliable, especially when working in closed VPCs)

#### Why the improvements

In my opinion when working with terraform external modules the less they do the better it is so it can be easily integrated with the existing infrastructure. Having the `security group` defined by the module doesn't allow specific customization of the security rules of the resulting drone `instance` (eg: do I want `ssh` port open or  not? do i want to block it by CIDR block on the subnet? do I want to allow traffic coming just from specific security groups?).

Also the SSH key generation is removed to allow the reusability of pre existing keys (what if every module creates its own key? the end result would be complex to manage due to multiple SSH keys present and moved across hosts)

Following the same logic I removed also the definition of the `aws provider` from the module to allow more custom usage of it (eg: not locked to use `aws keys`, aws suggested method is to always use aws profiles)