### PR TITLE
external volume encryption

### DIFF
--- a/drone-ci/drone/ansible/play.yml
+++ b/drone-ci/drone/ansible/play.yml
@@ -85,13 +85,18 @@
         pkg: "{{ item }}"
         state: present
       with_items: "{{ apt_packages }}"
-    - name: install docker-py
+    - name: install docker-py to latest
       become: yes
       pip:
-        name: "docker-py"
-        version: "1.9.0"
+        name: docker-py
+        state: latest
       environment:
         LC_ALL: "C"
+    - name: downgrade requests to 2.5.3
+      become: yes
+      pip:
+        name: requests
+        version: 2.5.3
     - name: add `ubuntu` to docker group
       user:
         append: yes

--- a/vault/ansible/play.yml
+++ b/vault/ansible/play.yml
@@ -17,11 +17,8 @@
     - include: ./tasks/install_docker.yml
     - name: pull needed images
       become: yes
-      docker_image:
-        name: "{{ item }}"
-      with_items:
-        - consul
-        - vault
+      shell:
+        cmd: "docker pull {{ item }}"
 
 - hosts: master
   remote_user: ubuntu

--- a/vault/ansible/play.yml
+++ b/vault/ansible/play.yml
@@ -42,17 +42,8 @@
         flat: yes
     - name: restart consul
       become: yes
-      docker_container:
-        name: consul
-        image: consul
-        state: started
-        restart: yes
-        network_mode: host
-        command: agent -server -ui
-        volumes:
-          /home/ubuntu/consul_config.json:/consul/config/local.json
-        env:
-          CONSUL_BIND_INTERFACE: "{{ interface_name }}"
+      shell:
+        cmd: "docker run -d --name consul -e CONSUL_BIND_INTERFACE={{ interface_name }} -v /home/ubuntu/consul_config.json:/consul/config/local.json --network=host consul agent -server -ui"
 
 - hosts: slaves
   remote_user: ubuntu
@@ -71,17 +62,8 @@
         dest: "~/consul_config.json"
     - name: restart consul
       become: yes
-      docker_container:
-        name: consul
-        image: consul
-        state: started
-        restart: yes
-        network_mode: host
-        command: agent -server -ui
-        volumes:
-          /home/ubuntu/consul_config.json:/consul/config/local.json
-        env:
-          CONSUL_BIND_INTERFACE: "{{ interface_name }}"
+      shell:
+        cmd: "docker run -d --name consul -e CONSUL_BIND_INTERFACE={{ interface_name }} -v /home/ubuntu/consul_config.json:/consul/config/local.json --network=host consul agent -server -ui"
     - name: register with master
       become: yes
       raw: "docker exec -it consul consul join {{ consul_master_ip }}"
@@ -102,14 +84,5 @@
         dest: "~/vault_config.json"
     - name: start vault
       become: yes
-      docker_container:
-        name: vault
-        image: vault
-        state: started
-        restart: yes
-        network_mode: host
-        command: server
-        capabilities:
-          - IPC_LOCK
-        volumes:
-          /home/ubuntu/vault_config.json:/vault/config/local.json
+      shell:
+        cmd: "docker run -d --name vault --network=host -v /home/ubuntu/vault_config.json:/vault/config/local.json --cap-add=IPC_LOCK vault server"

--- a/vault/ansible/play.yml
+++ b/vault/ansible/play.yml
@@ -11,6 +11,7 @@
         port=22
         state=started
     - include: ./tasks/fix.yml
+    - include: ./tasks/mount_docker_data.yml
     - include: ./tasks/install_docker.yml
     - name: pull needed images
       become: yes

--- a/vault/ansible/play.yml
+++ b/vault/ansible/play.yml
@@ -17,8 +17,8 @@
     - include: ./tasks/install_docker.yml
     - name: pull needed images
       become: yes
-      shell:
-        cmd: "docker pull {{ item }}"
+      docker_image:
+        name: "{{ item }}"
       with_items:
         - consul
         - vault
@@ -42,8 +42,17 @@
         flat: yes
     - name: restart consul
       become: yes
-      shell:
-        cmd: "docker run -d --name consul -e CONSUL_BIND_INTERFACE={{ interface_name }} -v /home/ubuntu/consul_config.json:/consul/config/local.json --network=host consul agent -server -ui"
+      docker_container:
+        name: consul
+        image: consul
+        state: started
+        restart: yes
+        network_mode: host
+        command: agent -server -ui
+        volumes:
+          /home/ubuntu/consul_config.json:/consul/config/local.json
+        env:
+          CONSUL_BIND_INTERFACE: "{{ interface_name }}"
 
 - hosts: slaves
   remote_user: ubuntu
@@ -62,8 +71,17 @@
         dest: "~/consul_config.json"
     - name: restart consul
       become: yes
-      shell:
-        cmd: "docker run -d --name consul -e CONSUL_BIND_INTERFACE={{ interface_name }} -v /home/ubuntu/consul_config.json:/consul/config/local.json --network=host consul agent -server -ui"
+      docker_container:
+        name: consul
+        image: consul
+        state: started
+        restart: yes
+        network_mode: host
+        command: agent -server -ui
+        volumes:
+          /home/ubuntu/consul_config.json:/consul/config/local.json
+        env:
+          CONSUL_BIND_INTERFACE: "{{ interface_name }}"
     - name: register with master
       become: yes
       raw: "docker exec -it consul consul join {{ consul_master_ip }}"
@@ -84,5 +102,14 @@
         dest: "~/vault_config.json"
     - name: start vault
       become: yes
-      shell:
-        cmd: "docker run -d --name vault --network=host -v /home/ubuntu/vault_config.json:/vault/config/local.json --cap-add=IPC_LOCK vault server"
+      docker_container:
+        name: vault
+        image: vault
+        state: started
+        restart: yes
+        network_mode: host
+        command: server
+        capabilities:
+          - IPC_LOCK
+        volumes:
+          /home/ubuntu/vault_config.json:/vault/config/local.json

--- a/vault/ansible/play.yml
+++ b/vault/ansible/play.yml
@@ -19,6 +19,9 @@
       become: yes
       shell:
         cmd: "docker pull {{ item }}"
+      with_items:
+        - consul
+        - vault
 
 - hosts: master
   remote_user: ubuntu

--- a/vault/ansible/play.yml
+++ b/vault/ansible/play.yml
@@ -4,6 +4,8 @@
   gather_facts: False
   vars:
     ansible_python_interpreter: "/usr/bin/python2.7"
+  vars_files:
+    - vars.yml
   tasks:
     - name: waiting for server to accept SSH connections
       local_action:

--- a/vault/ansible/tasks/fix.yml
+++ b/vault/ansible/tasks/fix.yml
@@ -2,17 +2,17 @@
   raw: sudo apt-get -y update
   register: result
   until: result|success
-  retries: 10
+  retries: 20
 - name: install python2
   raw: sudo apt-get update && sudo apt-get -y install python2.7
   register: result
   until: result|success
-  retries: 10
+  retries: 20
 - name: install aptitude
   raw: sudo apt-get update && sudo apt-get -y install aptitude
   register: result
   until: result|success
-  retries: 10
+  retries: 20
 - name: get instance hostname
   shell:
     cmd: cat /etc/hostname

--- a/vault/ansible/tasks/install_docker.yml
+++ b/vault/ansible/tasks/install_docker.yml
@@ -28,13 +28,18 @@
     - docker-engine
     - python-dev
     - python-pip
-- name: install docker-py
+- name: install docker-py to latest
   become: yes
   pip:
-    name: "docker-py"
-    version: "1.9.0"
+    name: docker-py
+    state: latest
   environment:
     LC_ALL: "C"
+- name: downgrade requests to 2.5.3
+  become: yes
+  pip:
+    name: requests
+    version: 2.5.3
 - name: add `ubuntu` to docker group
   become: yes
   user:

--- a/vault/ansible/tasks/mount_docker_data.yml
+++ b/vault/ansible/tasks/mount_docker_data.yml
@@ -15,3 +15,4 @@
   become: yes
   shell:
     cmd: "rm -rf {{ docker_data_dir }}/*"
+  ignore_errors: yes

--- a/vault/ansible/tasks/mount_docker_data.yml
+++ b/vault/ansible/tasks/mount_docker_data.yml
@@ -1,0 +1,17 @@
+- name: check external volume fs type
+  become: yes
+  filesystem:
+    fstype: ext4
+    dev: /dev/xvdh
+- name: mount data disk
+  become: yes
+  mount:
+    name: "{{ docker_data_dir }}"
+    src: /dev/xvdh
+    fstype: ext4
+    opts: rw
+    state: mounted
+- name: clean data folder
+  become: yes
+  shell:
+    cmd: "rm -rf {{ docker_data_dir }}/*"

--- a/vault/ansible/vars.yml
+++ b/vault/ansible/vars.yml
@@ -1,3 +1,6 @@
+## docker
+docker_data_dir: "/var/lib/docker"
+
 ## consul
 consul_datatcenter_name: dev
 consul_master_node_name: consul_master

--- a/vault/variables.tf
+++ b/vault/variables.tf
@@ -40,3 +40,7 @@ variable "volume_type" {
 variable "volume_size" {
   default = 50
 }
+
+variable "encryption_key" {
+  default = ""
+}

--- a/vault/variables.tf
+++ b/vault/variables.tf
@@ -31,3 +31,12 @@ variable "user_data" {
 variable "aws_iam_profile" {
   default = ""
 }
+
+variable "volume_type" {
+  type = "string"
+  default = "gp2"
+}
+
+variable "volume_size" {
+  default = 50
+}


### PR DESCRIPTION
This PR adds the capability to use encrypted disks when using the `vault` module.

it also fixes an incompatibility issued between `docker-py` and `requests`, both of them are python libraries used by ansible modules to manage containers. The error was found working with the latest version of `requests===1.21.x` that was throwing:

`Error connecting: Error while fetching server API version: Timeout value connect was Timeout(connect=60, read=60, total=None), but it must be an int, float or None.`

fixing the version of requests to `2.5.3` solved the issue. I've replicated the fix also for the drone module.