### PR TITLE
securing docker

### DIFF
--- a/packer/securing-docker/README.md
+++ b/packer/securing-docker/README.md
@@ -1,12 +1,12 @@
 ## Securing Docker Containers on AWS
 
-In 2015 the Docker team set out to consolidate all the information around best practices for securing docker containers.  You can find references to the [CIS Docker Community Edition Benchmark version 1.1.0](https://www.cisecurity.org/cis-benchmarks/) and Docker's own white paper [Introduction to Docker Security](https://d3oypxn00j2a10.cloudfront.net/assets/img/Docker%20Security/WP_Intro_to_container_security_03.20.2015.pdf) on the topic [here](https://blog.docker.com/2015/05/understanding-docker-security-and-best-practices/). The links above get you more directly to the assets. just an FYI, the CIS benchmark will cost you an email address for download.
+In 2015 the Docker team set out to consolidate all the information around best practices for securing docker containers.  You can find references to the [CIS Docker Community Edition Benchmark version 1.1.0](https://www.cisecurity.org/cis-benchmarks/) and Docker's own white paper [Introduction to Docker Security](https://d3oypxn00j2a10.cloudfront.net/assets/img/Docker%20Security/WP_Intro_to_container_security_03.20.2015.pdf) on the topic [here](https://blog.docker.com/2015/05/understanding-docker-security-and-best-practices/). The links above get you more directly to the assets. Just an FYI, the CIS benchmark will cost you an email address for download.
 
 On most projects at nearForm we are deploying our solutions within Docker containers. There are tasks that are repeated on each project to secure and harden off those deployments and we built this packer template to produce a quick and easy way for you to spin up an AWS AMI that passes the [Docker-Bench-Security](https://github.com/docker/docker-bench-security) script. The Docker-Bench-Security repo is a work product of the above mentioned consolidation efforts by the Docker team.
 
 To accomplish the building of this AMI we use [Packer](https://www.packer.io/), which is an easy way to automate the creation of your images.  It supports multiple providers (i.e. AWS, Digital Ocean) and allows you to document in a repo how your images were built and modifications that were done to them over time.
 
-The work to get this AMI passing the [Docker-Bench-Security](https://github.com/docker/docker-bench-security) was not a small task, but a critical task of any development organization. Minimizing the attack surface of an application we deploy into the wild will always return on investment. Whether that return comes from keeping an active attacker from escalating privileges and damaging our craft or simply letting you sleep at night knowning that you've done everything you can to secure your environments. Give it a spin and feel free to raise [issues or PRs](https://github.com/nearform/devops) if you find ways to improve upon the work.
+The work to get this AMI passing the [Docker-Bench-Security](https://github.com/docker/docker-bench-security) was not a small task, but a critical task of any development organization. Minimizing the attack surface of an application we deploy into the wild will always return on investment. Whether that return comes from keeping an active attacker from escalating privileges and damaging our craft or simply letting you sleep at night knowing that you've done everything you can to secure your environments. Give it a spin and feel free to raise [issues or PRs](https://github.com/nearform/devops) if you find ways to improve upon the work.
 
 #### Requirements 
 
@@ -40,7 +40,7 @@ Our example template uses packer's [amazon-ebs](https://www.packer.io/docs/build
 2. Create and mount the volume that will be used to store our Docker assets
 3. Install Docker CE
 4. Clone [Docker-Bench-Security](https://github.com/docker/docker-bench-security) 
-5. Install and configure auditd
+5. Install and configure [auditd](https://linux.die.net/man/8/auditd)
 
 #### Run an Instance of Your AMI
 Once packer has finished building your AMI, you can log into the AWS Console and launch an instance from the AMI.  You will only need to configure network related items (i.e. subnet) and the rest you should be able to take the defaults. Once your instance is up and running ssh into it and you should find docker-bench-security in the home directory of the ubuntu user. Do the following to run and verify the AMI passes the test we've documented above.

--- a/packer/securing-docker/README.md
+++ b/packer/securing-docker/README.md
@@ -1,0 +1,66 @@
+## Securing Docker Containers on AWS
+
+About two years ago the Docker team set out to consolidate all the information around best practices for securing docker containers.  You can find references to the [CIS Docker Community Edition Benchmark version 1.1.0](https://www.cisecurity.org/cis-benchmarks/) and Docker's own white paper [Introduction to Docker Security](https://d3oypxn00j2a10.cloudfront.net/assets/img/Docker%20Security/WP_Intro_to_container_security_03.20.2015.pdf) on the topic [here](https://blog.docker.com/2015/05/understanding-docker-security-and-best-practices/). The links above get you more directly to the assets. just an FYI, the CIS benchmark will cost you an email address for download.
+
+On most projects at nearForm we are deploying our solutions within Docker containers. There are tasks that are repeated on each project to secure and harden off those deployments and we built this packer template to produce a quick and easy way for you to spin up an AWS AMI that passes the [Docker-Bench-Security](https://github.com/docker/docker-bench-security) script. The Docker-Bench-Security repo is a work product of the above mentioned consolidation efforts by the Docker team.
+
+To accomplish the building of this AMI we use [Packer](https://www.packer.io/), which is an easy way to automate the creation of your images.  It supports multiple providers (i.e. AWS, Digital Ocean) and allows you to document in a repo how your images were built and modifications that were done to them over time.
+
+#### Requirements 
+
+- [Packer](https://www.packer.io/intro/getting-started/install.html)
+- [AWS account](https://aws.amazon.com/) - free tier will work with our examples.
+- [Security Credentials](https://console.aws.amazon.com/iam/home) from your AWS account
+
+#### Setup
+ 
+ 1. Setup packer
+ 2. `$ git clone <insert repo>`
+ 3. Create a file named `variables.json` in the root of the example repo from #2.  Add your access and secret keys. If you want to use a different region in AWS change the `aws_region` and find replace the `ubuntu_source_ami` with the AMI ID that has an instance type of `hvm-ssd` from [Ubuntu](https://cloud-images.ubuntu.com/locator/).  Your File should look something like this:
+ 
+``` json
+{
+  "aws_secret_key": "< INSERT YOUR SECRET KEY >",
+  "aws_access_key": "< INSERT YOUR ACCESS KEY >",
+  "aws_region": "us-east-1",
+  "ubuntu_source_ami": "ami-cb1d41b0"
+}
+```
+ 
+ #### Build the AMI
+ After executing the command below you should see an AMI in the [AWS Console](https://console.aws.amazon.com/ec2/v2/home?#Images)
+ 
+ `$ packer build -var-file=variables.json base-image-us-east-template.json`
+
+Our example template uses packer's [amazon-ebs](https://www.packer.io/docs/builders/amazon-ebs.html) builder.  We use a builder and two provisioners in our template to accomplish the following:
+
+1. Create /etc/docker/daemon.json
+2. Create and mount the volume that will be used to store our Docker assets
+3. Install Docker CE
+4. Clone [Docker-Bench-Security](https://github.com/docker/docker-bench-security) 
+5. Install and configure auditd
+
+#### Run an Instance of Your AMI
+Once packer has finished building your AMI, you can log into the AWS Console and launch an instance from the AMI.  You will only need to configure network related items (i.e. subnet) and the rest you should be able to take the defaults. Once your instance is up and running ssh into it and you should find docker-bench-security in the home directory of the ubuntu user. Do the following to run and verify the AMI passes the test we've documented above.
+
+1. `$ cd docker-bench-security`
+2. `$ sudo sh ./docker-bench-security.sh `
+ 
+*note*: sudo is used in step 2 due to checks against files and directories that require elevated privileges.
+
+#### Run a Container in your Instance
+If you would like to build a docker image and run a container based on that image you can include [./files/app/]() in your AMI build, which will give you a simple [hapi](https://hapijs.com/) app to run the [Docker-Bench-Security](https://github.com/docker/docker-bench-security) tests against.
+
+To include these files add the following to the provisioners section of the template
+
+```
+    {
+      "type": "shell",
+      "inline": ["mkdir ./app/"]
+    },   
+    {
+      "type": "file",
+      "source": "./files/app/",
+      "destination": "./app/"
+    }
+```

--- a/packer/securing-docker/README.md
+++ b/packer/securing-docker/README.md
@@ -1,10 +1,12 @@
 ## Securing Docker Containers on AWS
 
-About two years ago the Docker team set out to consolidate all the information around best practices for securing docker containers.  You can find references to the [CIS Docker Community Edition Benchmark version 1.1.0](https://www.cisecurity.org/cis-benchmarks/) and Docker's own white paper [Introduction to Docker Security](https://d3oypxn00j2a10.cloudfront.net/assets/img/Docker%20Security/WP_Intro_to_container_security_03.20.2015.pdf) on the topic [here](https://blog.docker.com/2015/05/understanding-docker-security-and-best-practices/). The links above get you more directly to the assets. just an FYI, the CIS benchmark will cost you an email address for download.
+In 2015 the Docker team set out to consolidate all the information around best practices for securing docker containers.  You can find references to the [CIS Docker Community Edition Benchmark version 1.1.0](https://www.cisecurity.org/cis-benchmarks/) and Docker's own white paper [Introduction to Docker Security](https://d3oypxn00j2a10.cloudfront.net/assets/img/Docker%20Security/WP_Intro_to_container_security_03.20.2015.pdf) on the topic [here](https://blog.docker.com/2015/05/understanding-docker-security-and-best-practices/). The links above get you more directly to the assets. just an FYI, the CIS benchmark will cost you an email address for download.
 
 On most projects at nearForm we are deploying our solutions within Docker containers. There are tasks that are repeated on each project to secure and harden off those deployments and we built this packer template to produce a quick and easy way for you to spin up an AWS AMI that passes the [Docker-Bench-Security](https://github.com/docker/docker-bench-security) script. The Docker-Bench-Security repo is a work product of the above mentioned consolidation efforts by the Docker team.
 
 To accomplish the building of this AMI we use [Packer](https://www.packer.io/), which is an easy way to automate the creation of your images.  It supports multiple providers (i.e. AWS, Digital Ocean) and allows you to document in a repo how your images were built and modifications that were done to them over time.
+
+The work to get this AMI passing the [Docker-Bench-Security](https://github.com/docker/docker-bench-security) was not a small task, but a critical task of any development organization. Minimizing the attack surface of an application we deploy into the wild will always return on investment. Whether that return comes from keeping an active attacker from escalating privileges and damaging our craft or simply letting you sleep at night knowning that you've done everything you can to secure your environments. Give it a spin and feel free to raise [issues or PRs](https://github.com/nearform/devops) if you find ways to improve upon the work.
 
 #### Requirements 
 
@@ -15,7 +17,7 @@ To accomplish the building of this AMI we use [Packer](https://www.packer.io/), 
 #### Setup
  
  1. Setup packer
- 2. `$ git clone <insert repo>`
+ 2. `$ git clone git@github.com:nearform/devops.git`
  3. Create a file named `variables.json` in the root of the example repo from #2.  Add your access and secret keys. If you want to use a different region in AWS change the `aws_region` and find replace the `ubuntu_source_ami` with the AMI ID that has an instance type of `hvm-ssd` from [Ubuntu](https://cloud-images.ubuntu.com/locator/).  Your File should look something like this:
  
 ``` json

--- a/packer/securing-docker/base-image-us-east-template.json
+++ b/packer/securing-docker/base-image-us-east-template.json
@@ -1,0 +1,44 @@
+{
+  "variables": {
+    "aws_access_key": "",
+    "aws_secret_key": "",
+    "aws_region": "",
+    "ubuntu_source_ami": ""
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "region": "{{user `aws_region`}}",
+      "source_ami": "{{user `ubuntu_source_ami`}}",
+      "instance_type": "t2.micro",
+      "ssh_username": "ubuntu",
+      "ami_name": "ubuntu-{{timestamp}}",
+      "ami_block_device_mappings": [
+        {
+          "volume_type" : "gp2",
+          "device_name" : "/dev/sdf",
+          "delete_on_termination" : false,
+          "volume_size" : 1
+        }
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "./files/daemon.json",
+      "destination": "/tmp/daemon.json"
+    },
+    {
+      "type": "shell",
+      "scripts": [
+        "./scripts/volume.sh",
+        "./scripts/docker-setup.sh",
+        "./scripts/docker-security.sh",
+        "./scripts/auditd-setup.sh"
+      ]
+    }
+  ]
+}

--- a/packer/securing-docker/files/app/Dockerfile
+++ b/packer/securing-docker/files/app/Dockerfile
@@ -1,0 +1,36 @@
+
+FROM node:8
+
+# Create the home directory for the new app user.
+RUN mkdir -p /home/app
+
+# Create an app user so our program doesn't run as root.
+RUN groupadd -r app &&\
+    useradd -r -g app -d /home/app -s /sbin/nologin -c "Docker image user" app
+
+# Set the home directory to our app user's home.
+ENV HOME=/home/app
+ENV APP_HOME=/home/app/test-server
+
+## SETTING UP THE APP ##
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME
+
+# Copy in the application code.
+COPY . $APP_HOME
+
+# Need to NPM prior to chown and switching user
+RUN npm install hapi --save
+
+HEALTHCHECK --interval=20s --timeout=3s \
+  CMD curl -f http://localhost:8000/hello || exit 1
+
+# Chown all the files to the app user.
+RUN chown -R app:app $APP_HOME
+
+# Change to the app user.
+USER app:app
+
+EXPOSE 8000
+
+CMD [ "node", "server.js" ]

--- a/packer/securing-docker/files/app/hapi-server.js
+++ b/packer/securing-docker/files/app/hapi-server.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Hapi = require('hapi');
+
+// Create a server with a host and port
+const server = new Hapi.Server();
+server.connection({ 
+    host: 'localhost', 
+    port: 8000 
+});
+
+// Add the route
+server.route({
+    method: 'GET',
+    path:'/hello', 
+    handler: function (request, reply) {
+
+        return reply('hello world');
+    }
+});
+
+// Start the server
+server.start((err) => {
+
+    if (err) {
+        throw err;
+    }
+    console.log('Server running at:', server.info.uri);
+});

--- a/packer/securing-docker/files/daemon.json
+++ b/packer/securing-docker/files/daemon.json
@@ -1,0 +1,12 @@
+{
+	"disable-legacy-registry": true,
+	"icc": false,
+	"live-restore": true,
+ 	"log-driver": "syslog",
+	"log-opts": {
+    	"syslog-address": "udp://1.2.3.4:1111"
+  	},
+	"storage-driver": "overlay2",
+	"userland-proxy": false,
+	"userns-remap": "default"
+}

--- a/packer/securing-docker/scripts/auditd-setup.sh
+++ b/packer/securing-docker/scripts/auditd-setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+sudo apt update
+sudo apt-get install -y auditd
+
+# 1.5  - Ensure auditing is configured for the Docker daemon
+echo "-w /usr/bin/docker -p wa" | sudo tee -a /etc/audit/rules.d/audit.rules
+# 1.6  - Ensure auditing is configured for Docker files and directories - /var/lib/docker
+echo "-w /var/lib/docker -p wa" | sudo tee -a /etc/audit/rules.d/audit.rules
+# 1.7  - Ensure auditing is configured for Docker files and directories - /etc/docker"
+echo "-w /etc/docker -p wa" | sudo tee -a /etc/audit/rules.d/audit.rules
+# 1.8  - Ensure auditing is configured for Docker files and directories - docker.service
+echo "-w /lib/systemd/system/docker.service -p wa" | sudo tee -a /etc/audit/rules.d/audit.rules
+# 1.9  - Ensure auditing is configured for Docker files and directories - docker.socket
+echo "-w /lib/systemd/system/docker.socket -p wa" | sudo tee -a /etc/audit/rules.d/audit.rules
+# 1.10 - Ensure auditing is configured for Docker files and directories - /etc/default/docker
+echo "-w /etc/default/docker -p wa" | sudo tee -a /etc/audit/rules.d/audit.rules
+# 1.11 - Ensure auditing is configured for Docker files and directories - /etc/docker/daemon.json
+echo "-w /etc/docker/daemon.json -p wa" | sudo tee -a /etc/audit/rules.d/audit.rules
+# 1.12 - Ensure auditing is configured for Docker files and directories - /usr/bin/docker-containerd
+echo "-w /usr/bin/docker-containerd -p wa" | sudo tee -a /etc/audit/rules.d/audit.rules
+# 1.13 - Ensure auditing is configured for Docker files and directories - /usr/bin/docker-runc
+echo "-w /usr/bin/docker-runc -p wa" | sudo tee -a /etc/audit/rules.d/audit.rules
+
+sudo service auditd restart
+
+## TODO: lock the audit configuration to prevent any modification of this file. 
+## If you want to be able to modify the audit rules again after locking you will have to reboot for changes to take place
+# -e 2

--- a/packer/securing-docker/scripts/docker-security.sh
+++ b/packer/securing-docker/scripts/docker-security.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+git clone https://github.com/docker/docker-bench-security.git

--- a/packer/securing-docker/scripts/docker-setup.sh
+++ b/packer/securing-docker/scripts/docker-setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# source => https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/
+
+sudo apt-get update
+
+sudo apt-get install -y \
+  linux-image-extra-$(uname -r) \
+  linux-image-extra-virtual
+
+sudo apt-get update
+sudo apt-get install -y \
+  apt-transport-https \
+  ca-certificates \
+  curl \
+  software-properties-common
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+sudo add-apt-repository \
+  "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) \
+  stable"
+
+sudo apt-get update
+sudo apt-get install -y docker-ce
+
+# add instance user to docker group so it can execute commands.
+sudo usermod -a -G docker ubuntu
+
+# 4.5  - Ensure Content trust for Docker is Enabled
+echo "DOCKER_CONTENT_TRUST=1" | sudo tee -a /etc/environment
+
+# config to implement changes for 2.1 - 2.15 
+sudo mv /tmp/daemon.json /etc/docker/daemon.json
+sudo chown root:root /etc/docker/daemon.json
+
+sudo service docker restart

--- a/packer/securing-docker/scripts/volume.sh
+++ b/packer/securing-docker/scripts/volume.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sudo mkfs -t ext4 /dev/xvdf
+sudo mkdir /mnt/data-store
+sudo mount /dev/xvdf /mnt/data-store
+
+echo "/var/lib/docker /mnt/data-store bind defaults,bind 0 0" | sudo tee -a /etc/fstab


### PR DESCRIPTION
The scripts within [./packer/securing-docker](./packer/securing-docker) support the blog post that was written on creating an AMI that passes the [Docker-Bench-Security](https://github.com/docker/docker-bench-security) script. Reason for adding these files to this repo is the blog post references them and it also gives them a long term home for future use on any project.  Feel free to review and make suggestions on improvements.  Sounds like the blog post will go live in a few weeks.

[Secure DevOps issue](https://github.com/nearform/pathfinders/issues/133)
[Blog Post PR](https://github.com/nearform/website2017/pull/280)

