### PR TITLE
Ensuring we actually are using a separate volume for Docker.

### DIFF
--- a/packer/securing-docker/base-image-us-east-template.json
+++ b/packer/securing-docker/base-image-us-east-template.json
@@ -15,6 +15,14 @@
       "instance_type": "t2.micro",
       "ssh_username": "ubuntu",
       "ami_name": "ubuntu-{{timestamp}}",
+      "launch_block_device_mappings": [
+        {
+          "volume_type" : "gp2",
+          "device_name" : "/dev/sdf",
+          "delete_on_termination" : false,
+          "volume_size" : 1
+        }
+      ],
       "ami_block_device_mappings": [
         {
           "volume_type" : "gp2",

--- a/packer/securing-docker/scripts/volume.sh
+++ b/packer/securing-docker/scripts/volume.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 sudo mkfs -t ext4 /dev/xvdf
-sudo mkdir /mnt/data-store
-sudo mount /dev/xvdf /mnt/data-store
+sudo mkdir -p /var/lib/docker
 
-echo "/var/lib/docker /mnt/data-store bind defaults,bind 0 0" | sudo tee -a /etc/fstab
+echo "/dev/xvdf /var/lib/docker ext4 defaults,nofail 0 0" | sudo tee -a /etc/fstab
+
+mount -a


### PR DESCRIPTION
The previous implementation is not setting up a separate partition for Docker correctly; instead it was creating a bind-mount with `/var/lib/docker` which is not the same as actually mounting the volume. This can be verified via a `df` and seeing that `/dev/xvdf` was not mounted anywhere, and also any Docker commands would continue to populate the root partition. The first command that was originally on line 5 was actually correct, however the `/etc/fstab` entry is incorrect and as such would cause it to be invalid on a reboot. However, due to the way that the Docker Bench Security tests are implemented - it literally is just checking to see if `/var/lib/docker` is referenced in `/etc/fstab`, which is why it passed the test.

This change will ensure that instead we create the `/var/lib/docker` directory (**Note:** We must make sure this is created prior to installing Docker, which we are already in the Packer template), adding the `/etc/fstab` entry to mount it appropriately, and then mounting it via `mount -a`